### PR TITLE
Allow build_vrt input list to have one item

### DIFF
--- a/rio_vrt/vrt.py
+++ b/rio_vrt/vrt.py
@@ -113,16 +113,16 @@ def build_vrt(
             bottom_.append(f.bounds.bottom)
 
     # get the spatial extend of the dataset
-    left = min(*left_)
-    bottom = min(*bottom_)
-    right = max(*right_)
-    top = max(*top_)
+    left = min(left_)
+    bottom = min(bottom_)
+    right = max(right_)
+    top = max(top_)
 
     # get the resolution
     if res == "highest":
-        xres, yres = max(*xres_), max(*yres_)
+        xres, yres = max(xres_), max(yres_)
     elif res == "lowest":
-        xres, yres = min(*xres_), min(*yres_)
+        xres, yres = min(xres_), min(yres_)
     elif res == "average":
         xres, yres = mean(xres_), mean(yres_)
     elif isinstance(res, tuple):

--- a/tests/test_rio_vrt.py
+++ b/tests/test_rio_vrt.py
@@ -74,6 +74,21 @@ def test_build_vrt_hollow(tiles: List[Path], data_dir: Path, file_regression) ->
         file_regression.check(vrt_tree, basename="hollow_vrt", extension=".vrt")
 
 
+def test_build_vrt_single(tiles: List[Path], data_dir: Path, file_regression) -> None:
+    """Test a complete vrt there is only one tile.
+
+    Args:
+        tiles: the list of tile path
+        data_dir: the data directory
+        file_regression: the pytest regression file fixture
+    """
+    tiles = [tiles[0]]
+    with NamedTemporaryFile(suffix=".vrt", dir=data_dir) as vrt_path:
+        file = rio_vrt.build_vrt(vrt_path.name, tiles, relative=True)
+        vrt_tree = BeautifulSoup(file.read_text(), "xml").prettify()
+        file_regression.check(vrt_tree, basename="single_vrt", extension=".vrt")
+
+
 def test_build_vrt_stack(tiles: List[Path], data_dir: Path, file_regression) -> None:
     """Test a complete vrt where some tiles are missing.
 

--- a/tests/test_rio_vrt/single_vrt.vrt
+++ b/tests/test_rio_vrt/single_vrt.vrt
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VRTDataset rasterXSize="197" rasterYSize="179">
+ <SRS>
+  PROJCS["WGS 84 / UTM zone 18N",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-75],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","32618"]]
+ </SRS>
+ <GeoTransform>
+  101985.0, 300.0379266750948, 0.0, 2826915.0, 0.0, -300.0379266750948
+ </GeoTransform>
+ <OverviewList resampling="nearest">
+  2 4 8
+ </OverviewList>
+ <VRTRasterBand band="1" dataType="Byte">
+  <Offset>
+   0.0
+  </Offset>
+  <Scale>
+   1.0
+  </Scale>
+  <ColorInterp>
+   Red
+  </ColorInterp>
+  <NoDataValue>
+   0.0
+  </NoDataValue>
+  <ComplexSource>
+   <SourceFilename relativeToVRT="1">
+    raw/tile0.tiff
+   </SourceFilename>
+   <SourceBand>
+    1
+   </SourceBand>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
+   <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
+   <NODATA>
+    0.0
+   </NODATA>
+  </ComplexSource>
+ </VRTRasterBand>
+ <VRTRasterBand band="2" dataType="Byte">
+  <Offset>
+   0.0
+  </Offset>
+  <Scale>
+   1.0
+  </Scale>
+  <ColorInterp>
+   Green
+  </ColorInterp>
+  <NoDataValue>
+   0.0
+  </NoDataValue>
+  <ComplexSource>
+   <SourceFilename relativeToVRT="1">
+    raw/tile0.tiff
+   </SourceFilename>
+   <SourceBand>
+    2
+   </SourceBand>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
+   <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
+   <NODATA>
+    0.0
+   </NODATA>
+  </ComplexSource>
+ </VRTRasterBand>
+ <VRTRasterBand band="3" dataType="Byte">
+  <Offset>
+   0.0
+  </Offset>
+  <Scale>
+   1.0
+  </Scale>
+  <ColorInterp>
+   Blue
+  </ColorInterp>
+  <NoDataValue>
+   0.0
+  </NoDataValue>
+  <ComplexSource>
+   <SourceFilename relativeToVRT="1">
+    raw/tile0.tiff
+   </SourceFilename>
+   <SourceBand>
+    3
+   </SourceBand>
+   <SourceProperties BlockXSize="197" BlockYSize="3" DataType="Byte" RasterXSize="197" RasterYSize="179"/>
+   <SrcRect xOff="0" xSize="197" yOff="0" ySize="179"/>
+   <DstRect xOff="0" xSize="197" yOff="0" ySize="179"/>
+   <NODATA>
+    0.0
+   </NODATA>
+  </ComplexSource>
+ </VRTRasterBand>
+</VRTDataset>


### PR DESCRIPTION
It is common in real data sets to need to variably build VRT files that only have one file sometimes and this is easily allowed.